### PR TITLE
fix: content not refreshing upon navigation

### DIFF
--- a/pages/[uid].vue
+++ b/pages/[uid].vue
@@ -3,7 +3,7 @@ import { components } from '~/slices'
 
 const prismic = usePrismic()
 const route = useRoute()
-const { data: page } = useAsyncData('[uid]', () =>
+const { data: page } = useAsyncData(route.params.uid, () =>
   prismic.client.getByUID('page', route.params.uid as string)
 )
 const settings = useSettings()

--- a/pages/articles/[uid].vue
+++ b/pages/articles/[uid].vue
@@ -11,7 +11,8 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 
 const prismic = usePrismic()
 const route = useRoute()
-const { data: article } = useAsyncData('articles/[uid]', () =>
+
+const { data: article } = useAsyncData(`articles/${route.params.uid}`, () =>
   prismic.client.getByUID('article', route.params.uid as string)
 )
 const { data: latestArticles } = useAsyncData('$latestArticles', () =>


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to starter maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes the navigation issue reported in https://github.com/prismicio/slice-machine/issues/1104:
- Open the demo site https://nuxt-starter-prismic-blog.vercel.app
- Click on an article
- Go back to the home page
- Click on another article
- Problem: The first article is displayed, the content is not refreshed with the content of the second article
  The same happens if you switch between the `Contact me` and `About` pages.

**Solution**: use the [key parameter](https://nuxt.com/docs/api/composables/use-async-data#params) on `useAsyncData` to make sure the request is unique to the content fetched. 

I'm not sure this is the proper way to handle this but it works. A preview of the fix was generate with `npm run generate` and deployed on https://mde-fork-nuxt-blog.vercel.app

## Checklist:

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.
